### PR TITLE
Respect envFromSecrets in connector definitions

### DIFF
--- a/charts/opencti/templates/connector/deployment.yaml
+++ b/charts/opencti/templates/connector/deployment.yaml
@@ -69,8 +69,8 @@ spec:
           {{- end }}
 
           # Special handling for OPENCTI_URL which is constructed from other values
-          {{- if not (hasKey .env "OPENCTI_URL") }}
           {{- if eq $.Values.env.APP__BASE_PATH "/" }}
+          {{- if not (hasKey $envList "OPENCTI_URL") }}
           - name: OPENCTI_URL
             value: "http://{{ include "opencti.fullname" $ }}-server:{{ $.Values.service.port }}"
           {{- else }}
@@ -80,7 +80,7 @@ spec:
           {{- end }}
 
           # Special handling for OPENCTI_TOKEN which is constructed from other values
-          {{- if and (not (hasKey .env "OPENCTI_TOKEN")) ($.Values.env.APP__ADMIN__TOKEN) }}
+          {{- if and (not (hasKey $envList "OPENCTI_TOKEN")) ($.Values.env.APP__ADMIN__TOKEN) }}
           - name: OPENCTI_TOKEN
             value: "{{ $.Values.env.APP__ADMIN__TOKEN }}"
           {{- end }}


### PR DESCRIPTION
Makes connectors recognize OPENCTI_TOKEN and OPENCTI_URL env vars when passed from envFromSecrets.

This PR should trigger basic linting.